### PR TITLE
FreeBSD Compatibility Patch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ vul: vul.sh vul.awk vul.tsv
 	cat vul.sh > $@
 	echo 'exit 0' >> $@
 	echo "#EOF" >> $@
-	tar cz vul.awk vul.tsv >> $@
+	tar czf - vul.awk vul.tsv >> $@
 	chmod +x $@
 
 test: vul.sh

--- a/vul.sh
+++ b/vul.sh
@@ -5,7 +5,7 @@
 SELF="$0"
 
 get_data() {
-	sed '1,/^#EOF$/d' < "$SELF" | tar xz -O "$1"
+	sed '1,/^#EOF$/d' < "$SELF" | tar xzf - -O "$1"
 }
 
 if [ -z "$PAGER" ]; then


### PR DESCRIPTION
Changed in Makefile & vul.sh:
_Explicitly set tar output file to standard._

Fixes for FreeBSD. Also tested & working in Manjaro Linux. Changes no operations.